### PR TITLE
sdvx: add MAXXIVE CLEAR lamp to VF calculation

### DIFF
--- a/documentation/algorithms/volforce.md
+++ b/documentation/algorithms/volforce.md
@@ -76,6 +76,7 @@ VF5 is volforce as it was implemented in SOUND VOLTEX 5. It was introduced in 20
 		| "FAILED"
 		| "CLEAR"
 		| "EXCESSIVE CLEAR"
+		| "MAXXIVE CLEAR"
 		| "ULTIMATE CHAIN"
 		| "PERFECT ULTIMATE CHAIN";
 	```

--- a/library/src/algorithms/volforce.test.ts
+++ b/library/src/algorithms/volforce.test.ts
@@ -798,6 +798,7 @@ t.test("VF6 Tests", (t) => {
 		// differentiates Volforce values here -- unlike in VF5 where these would be
 		// marked as the same.
 		VF6TestCase(19, 9_500_000, "EXCESSIVE CLEAR", 0.357),
+		VF6TestCase(18, 9_923_042, "MAXXIVE CLEAR", 0.390),
 		VF6TestCase(19, 9_500_000, "CLEAR", 0.35),
 		VF6TestCase(19, 9_500_000, "FAILED", 0.175),
 
@@ -834,6 +835,7 @@ t.test("InverseVF6 Tests", (t) => {
 
 	const testCases = [
 		InvVF6TestCase(20, 0.413, "CLEAR", 9_900_000),
+		InvVF6TestCase(20, 0.232, "MAXXIVE CLEAR", 6_971_154),
 		InvVF6TestCase(20, 0.421, "EXCESSIVE CLEAR", 9_900_000),
 		InvVF6TestCase(13, 0.121, "CLEAR", 5_817_308),
 		InvVF6TestCase(13, 0.121, "FAILED", 9_595_559),

--- a/library/src/algorithms/volforce.ts
+++ b/library/src/algorithms/volforce.ts
@@ -7,6 +7,7 @@ export type SDVXLamps =
 	| "FAILED"
 	| "CLEAR"
 	| "EXCESSIVE CLEAR"
+	| "MAXXIVE CLEAR"
 	| "ULTIMATE CHAIN"
 	| "PERFECT ULTIMATE CHAIN";
 
@@ -41,6 +42,7 @@ const VF5GradeCoefficients: Record<SDVXGrades, number> = {
 const VF5LampCoefficients: Record<SDVXLamps, number> = {
 	"PERFECT ULTIMATE CHAIN": 110,
 	"ULTIMATE CHAIN": 105,
+	"MAXXIVE CLEAR": 104,
 	"EXCESSIVE CLEAR": 102,
 	CLEAR: 100,
 	FAILED: 50,


### PR DESCRIPTION
Add MAXXIVE CLEAR Volforce calculation adjustments

MAXXIVE RATE is a new guage added to arcade version of SDVX. The VF multiplier for playing on this is 1.04.

https://x.com/SOUNDVOLTEX573/status/1914257892028588220
https://www.sdvx.org/en/compendium/volforce
